### PR TITLE
Highlight instructions with {cond} at the very end

### DIFF
--- a/syntax/include/arm_base_syntax.vim
+++ b/syntax/include/arm_base_syntax.vim
@@ -48,15 +48,21 @@ let armCond = '\%(AL\|CC\|CS\|EQ\|GE\|GT\|HI\|HS\|LE\|LO\|LS\|LT\|MI\|NE\|PL\|VC
 " ARMv4 and thumb instructions
 " 
 exec 'syn match armv4Instr "\%(ADC\|ADD\|AND\|ASR\|BIC\|EOR\|LSL\|LSR\|MLA\|MOV\|MUL\|MVN\|NEG\|ORR\|ROR\|RRX\|RSB\|RSC\|SBC\|SMLAL\|SMULL\|SUB\|UMLAL\|UMULL\)' . armCond . 'S\?\>"'
+exec 'syn match armv4Instr "\%(ADC\|ADD\|AND\|ASR\|BIC\|EOR\|LSL\|LSR\|MLA\|MOV\|MUL\|MVN\|NEG\|ORR\|ROR\|RRX\|RSB\|RSC\|SBC\|SMLAL\|SMULL\|SUB\|UMLAL\|UMULL\)S' . armCond . '\>"'
 
 exec 'syn match armv4InstrCond  "\%(B\|BL\|BX\|CDP\|CMN\|CMP\|LDC\|MCR\|MRC\|MRS\|MSR\|NOP\|POP\|PUSH\|STC\|SWI\|TEQ\|TST\)' . armCond . '\>"'
 
 exec 'syn match armv4InstrCond  "ADR' . armCond . 'L\?\>"'
+exec 'syn match armv4InstrCond  "ADRL' . armCond . '\>"'
 
 exec 'syn match armv4LDR    "\%(LDR\)' . armCond . '\%(B\?T\?\|H\|S[BH]\)\?\>"'
+exec 'syn match armv4LDR    "LDR\%(B\?T\?\|H\|S[BH]\)' . armCond . '\>"'
 exec 'syn match armv4STR    "\%(STR\)' . armCond . '\%(B\?T\?\|H\)\?\>"'
+exec 'syn match armv4STR    "STR\%(B\?T\?\|H\)' . armCond . '\>"'
 exec 'syn match armv4Stack  "\%(LDM\|STM\)' . armCond . '\%([ID][BA]\|[EF][DA]\)\>"'
+exec 'syn match armv4Stack  "\%(LDM\|STM\)\%([ID][BA]\|[EF][DA]\)' . armCond . '\>"'
 exec 'syn match armv4SWP    "SWP' . armCond . 'B\?\>"'
+exec 'syn match armv4SWP    "SWPB' . armCond . '\>"'
 
 "syn match armRelative      "@R[0-7]\|@a\s*+\s*dptr\|@[ab]"
 

--- a/syntax/include/armv5_base_syntax.vim
+++ b/syntax/include/armv5_base_syntax.vim
@@ -14,7 +14,9 @@ HiLink armv4InstrNoCond armv5InstrNoCond
 exec 'syn match armv5Mul "\%(SMLA\|SMLAL\|SMLAW\|SMUL\|SMULW\)[BT][BT]\?' . armCond . '\>"'
 
 exec 'syn match armv5LDR    "\%(LDR\)' . armCond . 'D\>"'
+exec 'syn match armv5LDR    "LDRD' . armCond . '\>"'
 exec 'syn match armv5STR    "\%(STR\)' . armCond . 'D\>"'
+exec 'syn match armv5STR    "STRD' . armCond . '\>"'
 HiLink armv4LDR  armv5LDR
 HiLink armv4STR  armv5STR
 


### PR DESCRIPTION
When trying to use e.g. `ADR{cond}L` in the unified syntax, the GNU assembler warns that the conditional infixes are deprecated. The preferred form is `ADRL{cond}` instead. It is also in line with [arm.com](https://developer.arm.com/documentation/dui0802/b/A32-and-T32-Instructions/ADRL-pseudo-instruction) and [keil.com](https://www.keil.com/support/man/docs/armasm/armasm_dom1361289862667.htm) documentation.

This applies to other instructions that have optional parts (e.g. `S` for updating condition flags) - the condition goes last.

```
$ arm-none-eabi-as <<< ".syntax unified; label: adreql r0, label"
{standard input}: Assembler messages:
{standard input}:1: conditional infixes are deprecated in unified syntax

$ arm-none-eabi-as <<< ".syntax unified; label: adrleq r0, label"
[no output, everything fine]
```