### PR TITLE
base syntax: support SVC, UAL suffix-less LDM/STM

### DIFF
--- a/syntax/include/arm_base_syntax.vim
+++ b/syntax/include/arm_base_syntax.vim
@@ -50,7 +50,7 @@ let armCond = '\%(AL\|CC\|CS\|EQ\|GE\|GT\|HI\|HS\|LE\|LO\|LS\|LT\|MI\|NE\|PL\|VC
 exec 'syn match armv4Instr "\%(ADC\|ADD\|AND\|ASR\|BIC\|EOR\|LSL\|LSR\|MLA\|MOV\|MUL\|MVN\|NEG\|ORR\|ROR\|RRX\|RSB\|RSC\|SBC\|SMLAL\|SMULL\|SUB\|UMLAL\|UMULL\)' . armCond . 'S\?\>"'
 exec 'syn match armv4Instr "\%(ADC\|ADD\|AND\|ASR\|BIC\|EOR\|LSL\|LSR\|MLA\|MOV\|MUL\|MVN\|NEG\|ORR\|ROR\|RRX\|RSB\|RSC\|SBC\|SMLAL\|SMULL\|SUB\|UMLAL\|UMULL\)S' . armCond . '\>"'
 
-exec 'syn match armv4InstrCond  "\%(B\|BL\|BX\|CDP\|CMN\|CMP\|LDC\|MCR\|MRC\|MRS\|MSR\|NOP\|POP\|PUSH\|STC\|SWI\|TEQ\|TST\)' . armCond . '\>"'
+exec 'syn match armv4InstrCond  "\%(B\|BL\|BX\|CDP\|CMN\|CMP\|LDC\|MCR\|MRC\|MRS\|MSR\|NOP\|POP\|PUSH\|STC\|SWI\|SVC\|TEQ\|TST\)' . armCond . '\>"'
 
 exec 'syn match armv4InstrCond  "ADR' . armCond . 'L\?\>"'
 exec 'syn match armv4InstrCond  "ADRL' . armCond . '\>"'
@@ -59,8 +59,8 @@ exec 'syn match armv4LDR    "\%(LDR\)' . armCond . '\%(B\?T\?\|H\|S[BH]\)\?\>"'
 exec 'syn match armv4LDR    "LDR\%(B\?T\?\|H\|S[BH]\)' . armCond . '\>"'
 exec 'syn match armv4STR    "\%(STR\)' . armCond . '\%(B\?T\?\|H\)\?\>"'
 exec 'syn match armv4STR    "STR\%(B\?T\?\|H\)' . armCond . '\>"'
-exec 'syn match armv4Stack  "\%(LDM\|STM\)' . armCond . '\%([ID][BA]\|[EF][DA]\)\>"'
-exec 'syn match armv4Stack  "\%(LDM\|STM\)\%([ID][BA]\|[EF][DA]\)' . armCond . '\>"'
+exec 'syn match armv4Stack  "\%(LDM\|STM\)' . armCond . '\%([ID][BA]\|[EF][DA]\)\?\>"'
+exec 'syn match armv4Stack  "\%(LDM\|STM\)\%([ID][BA]\|[EF][DA]\)\?' . armCond . '\>"'
 exec 'syn match armv4SWP    "SWP' . armCond . 'B\?\>"'
 exec 'syn match armv4SWP    "SWPB' . armCond . '\>"'
 


### PR DESCRIPTION
SVC is the new and preferred name for the SWI instruction as of ARMv7.

ARM's Unified Assembler Language recommends using `STM` and `LDM` in place of `STMIA` and `LDMIA`, which is the default addressing mode.